### PR TITLE
Support TamperMonkey, don't rely on func->string

### DIFF
--- a/blockblockadblock.js
+++ b/blockblockadblock.js
@@ -3,7 +3,7 @@
 // @description This prevents the BlockAdBlock anti-Adblock script from working.
 // @name Block BlockAdBlock
 // @namespace greasyfork.org
-// @version 1.0.0
+// @version 0.0.1
 // @icon https://adblockplus.org/favicon.ico
 // @include *
 // @license MIT

--- a/blockblockadblock.js
+++ b/blockblockadblock.js
@@ -1,16 +1,30 @@
-function injected() {
-    var descriptor = {
-        value: {},
-        writable: false,
-        configurable: false,
-    };
+// ==UserScript==
+// @author Charlie Somerville
+// @description This prevents the BlockAdBlock anti-Adblock script from working.
+// @name Block BlockAdBlock
+// @namespace greasyfork.org
+// @version 1.0.0
+// @icon https://adblockplus.org/favicon.ico
+// @include *
+// @license MIT
+// @grant none
+// @run-at document-start
+// @copyright 2016 Charlie Somerville
+// ==/UserScript==
 
-    Object.defineProperty(window, "BlockAdBlock", descriptor);
-    Object.defineProperty(window, "blockAdBlock", descriptor);
-}
+var injected = '(function () {\n' +
+'    var descriptor = {\n' +
+'        value: {},\n' +
+'        writable: false,\n' +
+'        configurable: false,\n' +
+'    };\n' +
+'\n'
+'    Object.defineProperty(window, "BlockAdBlock", descriptor);\n' +
+'    Object.defineProperty(window, "blockAdBlock", descriptor);\n' +
+'})();';
 
 var script = document.createElement("script");
 
-script.appendChild(document.createTextNode("(" + injected + ")();"));
+script.appendChild(document.createTextNode(injected);
 
 document.children[0].appendChild(script);


### PR DESCRIPTION
It would be nice to be able to hook into the BlockBlockAdBlock.js file on GreasyFork, for the benefit of TamperMonkey users, and it seems unsafe to rely on how the browser would represent a function as a string (especially important if this script could be used on non-Chromium-based browsers).
